### PR TITLE
fix: handle circular refs in secret redaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "turbo": "^2.0.0",
     "prettier": "^3.3.2",
     "eslint": "^9.7.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^1.6.1"
   },
   "workspaces": [
     "apps/*",

--- a/packages/common/src/util.test.ts
+++ b/packages/common/src/util.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "vitest";
+import { redactSecrets } from "./util";
+
+test("redactSecrets masks secret fields", () => {
+  const obj = { apiKey: "123", nested: { password: "abc", other: "ok" } };
+  const redacted = redactSecrets(obj);
+  expect(redacted.apiKey).toBe("****");
+  expect(redacted.nested.password).toBe("****");
+  expect(redacted.nested.other).toBe("ok");
+});
+
+test("redactSecrets handles circular references", () => {
+  const obj: any = { token: "123" };
+  obj.self = obj;
+  const redacted = redactSecrets(obj);
+  expect(redacted.self).toBe("[Circular]");
+});

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -3,11 +3,20 @@ export function expBackoff(attempt: number, baseMs: number = 1000) {
   return Math.min(30_000, Math.round((2 ** attempt) * baseMs));
 }
 export function redactSecrets(obj: any) {
+  return _redactSecrets(obj, new WeakSet());
+}
+
+function _redactSecrets(obj: any, seen: WeakSet<any>): any {
   if (obj == null || typeof obj !== "object") return obj;
+  if (seen.has(obj)) return "[Circular]";
+  seen.add(obj);
   const clone: any = Array.isArray(obj) ? [] : {};
   for (const [k, v] of Object.entries(obj)) {
-    if (typeof v === "string" && /key|secret|token|password/i.test(k)) clone[k] = "****";
-    else clone[k] = redactSecrets(v);
+    if (typeof v === "string" && /key|secret|token|password/i.test(k)) {
+      clone[k] = "****";
+    } else {
+      clone[k] = _redactSecrets(v, seen);
+    }
   }
   return clone;
 }


### PR DESCRIPTION
## Summary
- avoid infinite recursion in `redactSecrets`
- add unit tests for secret redaction

## Testing
- `pnpm exec vitest run packages/common/src/util.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b1adcba10832e8ac11b4bbcbe8192