### PR TITLE
Preserve node_modules when running services in Docker

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -19,6 +19,7 @@ services:
     command: ["pnpm","--filter","@flowforge/api","dev"]
     volumes:
       - ..:/repo
+      - node_modules:/repo/node_modules
   worker:
     build:
       context: ..
@@ -36,6 +37,7 @@ services:
     ports: []
     volumes:
       - ..:/repo
+      - node_modules:/repo/node_modules
   web:
     build:
       context: ..
@@ -50,6 +52,7 @@ services:
       VITE_API_BASE: http://api:3000
     volumes:
       - ..:/repo
+      - node_modules:/repo/node_modules
   db:
     image: postgres:16-alpine
     environment:
@@ -77,3 +80,4 @@ services:
 volumes:
   pgdata:
   minio:
+  node_modules:


### PR DESCRIPTION
## Summary
- mount a dedicated node_modules volume for api, worker and web services
- declare the shared node_modules named volume in docker compose

## Testing
- `docker-compose -f docker/compose.yml config`

------
https://chatgpt.com/codex/tasks/task_e_689b1f3cc214832e89c12c6062048f8c