### PR TITLE
chore: add pnpm workspace config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - packages/*


### PR DESCRIPTION
## Summary
- add `pnpm-workspace.yaml` so that pnpm treats apps and packages as part of the workspace

## Testing
- `pnpm install` *(fails: No matching version found for fastify-websocket@^8.3.1)*
- `pnpm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b2a5b7f08832ebc55d9139e02da45